### PR TITLE
Changed cba settings path for RR_Commons_Resources hemtt switch

### DIFF
--- a/cba_settings.sqf
+++ b/cba_settings.sqf
@@ -46,4 +46,4 @@ force ace_advanced_ballistics_enabled = false;
 /**********************************************
 	!! AB HIER NICHT LÖSCHEN ODER EDITIEREN !!
 **********************************************/
-#include "\RR_commons_resources\modKonfigurationsTemplates\CBA_Settings.h"
+#include "\z\RR_commons\addons\main\modKonfigurationsTemplates\CBA_Settings.h"


### PR DESCRIPTION
When RR_Commons_Resources is switched to HEMTT, the path of the CBA_Settings.h has to be changed.
This is done in this PR.